### PR TITLE
hotfix/add dotenv as dependency instead of dev dependency

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -5,18 +5,17 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "songify",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.1",
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
+        "dotenv": "^10.0.0",
         "express": "^4.17.1",
         "nodemon": "^2.0.12",
         "save-dev": "^0.0.1-security"
-      },
-      "devDependencies": {
-        "dotenv": "^10.0.0"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -508,7 +507,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -2073,8 +2071,7 @@
     "dotenv": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "dev": true
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
     "duplexer3": {
       "version": "0.1.4",

--- a/server/package.json
+++ b/server/package.json
@@ -14,11 +14,9 @@
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
+    "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "nodemon": "^2.0.12",
     "save-dev": "^0.0.1-security"
-  },
-  "devDependencies": {
-    "dotenv": "^10.0.0"
   }
 }


### PR DESCRIPTION
update dotenv to dependency instead of dev dependency - I believe saving dotenv as a dev dependency caused an error in Heroku deployment as the following error was found in the logs: 
```
Error: Cannot find module 'dotenv'
```