### PR TITLE
Feature/add track id to track data pulled from spotify api

### DIFF
--- a/server/controller/SearchController.js
+++ b/server/controller/SearchController.js
@@ -83,7 +83,7 @@ module.exports = {
                 
 
                 let songListData = await rawSongData.data.tracks.items
-                let trackData = await songListData.map((track) => ({song: track.name, artist: track.artists[0].name}));
+                let trackData = await songListData.map((track) => ({song: track.name, artist: track.artists[0].name, id: track.id}));
                 res.send(trackData)    
                 
         }


### PR DESCRIPTION
Add track id to data pulled from Spotify API, this servers as a unique identifier and can be used in the front end to display songs the user searches for 